### PR TITLE
Fill map background while panning

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -527,6 +527,7 @@ label {
 .smap {
     height: 100%;
     margin-bottom: 5px;
+    background: #ccc;
 }
 
 .smap-collapsible-max-max {


### PR DESCRIPTION
It looked like this:

![Screenshot 2021-02-18 at 17 20 38](https://user-images.githubusercontent.com/385047/108387437-dfcfa200-720d-11eb-8ae0-8b9e8871e406.png)


Adding a background solves this bug (if its not intended 😅 )